### PR TITLE
launch hyprpaper with specified config file

### DIFF
--- a/hyprpaper-gen.sh
+++ b/hyprpaper-gen.sh
@@ -233,10 +233,10 @@ scan_current_config;
 generate_config;
 
 if $start_hyprpaper && ! pgrep -x "hyprpaper" > /dev/null; then
-    hyprpaper &
+    hyprpaper -c $config_file &
 fi
 
 if $restart_hyprpaper; then 
     killall hyprpaper; 
-    hyprpaper & 
+    hyprpaper -c $config_file & 
 fi


### PR DESCRIPTION
hyprpaper is not being launched with the specified config file. Instead, it uses the default config located at ~/.config/hypr/hyprpaper.conf. This change allows hyprpaper to use the specified config file by supplying the $config_file variable to hyprpaper using -c argument.
