### PR TITLE
feat: follow symlinks too while searching for random wallpapers

### DIFF
--- a/hyprpaper-gen.sh
+++ b/hyprpaper-gen.sh
@@ -80,7 +80,7 @@ scan_current_config() {
 
         # Store wallpaper paths, if directory and wallpapers do exist
         if [ -d "$wallpaper_dir" ]; then
-            all_wallpapers=($(find "$wallpaper_dir" -maxdepth 1 -type f 2>/dev/null))
+            all_wallpapers=($(find -L "$wallpaper_dir" -maxdepth 1 -type f 2>/dev/null))
         else
             echo "$wallpaper_dir directory doesn't exist!"
             echo "'$this_script_name -w /path/to/wallpaper_directory' to set custom directory"


### PR DESCRIPTION
This feature is useful in case one uses symlinks to link wallpaper images from various sources into their wallpapers directory.
Example, using git submodules for fetching wallpapers from various git repos and symlinking them into a single wallpapers directory
